### PR TITLE
Browser adaptor interface

### DIFF
--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -8,7 +8,7 @@ var DEFAULT_DIFFER = require('looks-same');
 * Module for file system interaction
 * @const
 */
-var DEFAULT_FS = require('fs');
+var DEFAULT_FS = require('./fs-adaptor.js');
 
 /**
 * Root directory of the screenshots
@@ -55,33 +55,29 @@ function Mugshot(browser, options) {
 Mugshot.prototype.test = function(captureItem) {
   var fs = this._options.fs,
       browser = this._browser,
-      differ = this._options.differ,
-      screenshot = null,
-      baseline = null;
+      differ = this._options.differ;
 
-  browser.takeScreenshot(function(error, base64) {
-    screenshot = base64;
+  browser.takeScreenshot(function(error, screenshot) {
 
-    fs.exists(captureItem.name, function(err, exists) {
+    fs.exists(captureItem.name, function(error, exists) {
       if (!exists) {
-        fs.writeFile(captureItem.name, screenshot, 'base64', function(err) {
+        fs.writeFile(captureItem.name, screenshot, function(error) {
 
         });
       }
       else {
-        fs.readFile(captureItem.name, 'base64', function(err, data) {
-          baseline = data;
+        fs.readFile(captureItem.name, function(error, baseline) {
 
-          differ.isEqual(baseline, screenshot, function(err, equal) {
+          differ.isEqual(baseline, screenshot, function(error, equal) {
             if (!equal) {
-              differ.createDiff(baseline, screenshot, function(err, diff) {
+              differ.createDiff(baseline, screenshot, function(error, diff) {
                 var diffName = captureItem.name + '.diff.png';
-                fs.writeFile(diffName, diff, 'base64', function(err) {
+                fs.writeFile(diffName, diff, function(error) {
 
                 });
 
                 var screenshotName = captureItem.name + '.new.png';
-                fs.writeFile(screenshotName, screenshot, 'base64', function(err) {
+                fs.writeFile(screenshotName, screenshot, function(error) {
 
                 });
               });

--- a/test/mugshot-flow.js
+++ b/test/mugshot-flow.js
@@ -56,7 +56,8 @@ describe('Mugshot', function() {
 
     mugshot.test(dummySelector);
 
-    expect(FS.writeFile).to.have.been.calledWith(dummySelector.name, screenshot);
+    expect(FS.writeFile).to.have.been.calledWith(dummySelector.name, screenshot,
+      sinon.match.func);
   });
 
   it('should not write the screenshot on disk if there is already a baseline',
@@ -73,7 +74,8 @@ describe('Mugshot', function() {
 
     mugshot.test(dummySelector);
 
-    expect(FS.readFile).to.have.been.calledWith(dummySelector.name);
+    expect(FS.readFile).to.have.been.calledWith(dummySelector.name,
+      sinon.match.func);
   });
 
   it('should not read a baseline from disk if there is none', function() {
@@ -132,7 +134,8 @@ describe('Mugshot', function() {
 
     mugshot.test(dummySelector);
 
-    expect(FS.writeFile).to.have.been.calledWith(diffName, diff);
+    expect(FS.writeFile).to.have.been.calledWith(diffName, diff,
+      sinon.match.func);
   });
 
   it('should not call the fs to write the diff on disk if there is none',
@@ -156,6 +159,7 @@ describe('Mugshot', function() {
 
     mugshot.test(dummySelector);
 
-    expect(FS.writeFile).to.have.been.calledWith(screenshotName, screenshot);
+    expect(FS.writeFile).to.have.been.calledWith(screenshotName, screenshot,
+      sinon.match.func);
   });
 });


### PR DESCRIPTION
## Need

```
As a developer
I want a common interface for the browser
So that I can take screenshots with different instances
```
## Deliverables

Browser adaptor interface
## Solution

We need to give a retouch to the implementation, because the `screenshot` method from the WD Wire Protocol is asynchronous, so:

``` js
var browser = {
  /*
  * @param {takeScreenshotCb} callback
  */
  takeScreenshot: function(callback) {

  }

  /*
  * @callback takeScreenshotCb
  * @param error
  * @param {String} base64
  */
};
```

There is only one test that effectively test the browser interaction:

> should call the browser to take a screenshot

But all tests must be refurbished, because all the other code will enter in the `takeScreenshot callback`, so every test will receive a line, like this: `browser.takeScreenshot.yields(null, screenshot)`
