### PR TITLE
WebdriverIO browser adaptor update

### DIFF
--- a/lib/adaptors/webdriverio.js
+++ b/lib/adaptors/webdriverio.js
@@ -6,8 +6,8 @@ function WebDriverIOAdaptor(webdriverioInstance) {
 }
 
 WebDriverIOAdaptor.prototype = objectAssign({}, Browser, {
-  takeScreenshot: function() {
-    this._webdriverio.saveScreenshot();
+  takeScreenshot: function(callback) {
+    this._webdriverio.saveScreenshot(callback);
   }
 });
 


### PR DESCRIPTION
## Need

```
As a developer
I need to have a good browser adaptor that really have a browser instance
So that I can navigate on the web and take nice screenshots
```
## Deliverables
- [x] the adaptor will have internally the WebdriverIO instance
## Solution

Create a constructor `WebDriverIOAdaptor`, and set it's `prototype` equal to the `Browser Interface`. With the module `object-assign`, it will override the default methods from the interface.
