### PR TITLE
Delete old diff and screenshot images

### DIFF
--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -152,8 +152,17 @@ Mugshot.prototype.test = function(captureItem) {
                   });
                 });
               } else {
-                fs.unlink(diffPath, function() {});
-                fs.unlink(screenshotPath, function() {});
+                fs.unlink(diffPath, function(error) {
+                  if (error && error.code !== 'ENOENT') {
+                    throw error;
+                  }
+                });
+
+                fs.unlink(screenshotPath, function(error) {
+                  if (error && error.code !== 'ENOENT') {
+                    throw error;
+                  }
+                });
               }
             });
           });

--- a/test/mugshot-flow.js
+++ b/test/mugshot-flow.js
@@ -296,4 +296,22 @@ describe('Mugshot', function() {
 
     expect(FS.unlink).to.not.have.been.called;
   });
+
+  it('should not throw an error if the file is not there', function() {
+    var error = {code: 'ENOENT'};
+    FS.exists.yields(true);
+    FS.readFile.yields(null, baseline);
+    differ.isEqual.yields(null, true);
+
+    expect(mugshot.test.bind(mugshot, dummySelector)).to.not.throw(error);
+  });
+
+  it('should throw an error if the file couldn\'t be unlinked', function() {
+    FS.exists.yields(true);
+    FS.readFile.yields(null, baseline);
+    differ.isEqual.yields(null, true);
+    FS.unlink.yields(error);
+
+    expect(mugshot.test.bind(mugshot, dummySelector)).to.throw(Error);
+  });
 });


### PR DESCRIPTION
## Need

```
As a developer
I want a good app logic
So that I can do clean up and don't load the disk
```
## Deliverables

Removes inutile `diff` and `screenshot` from disk.
## Solution

Every time the `differ` method `isEqual` returns `true` we will try to unlink the `screenshot and diff image`, if there are any (maybe the user has already deleted it). This two calls will not throw any error.
