### PR TITLE
Extending browser interface getBoundingClientRect

### DIFF
--- a/lib/interfaces/browser.js
+++ b/lib/interfaces/browser.js
@@ -38,7 +38,7 @@ module.exports = {
  * @callback getClientBoundingRect
  * @param error
  * @param {Object} rect
- * @param {Object} rect.width
+ * @param {Number} rect.width
  * @param {Number} rect.height
  * @param {Number} rect.top
  * @param {Number} rect.right


### PR DESCRIPTION
## Need

```
As a developer
I want to have a method that gets the position of an element
So that I can crop it out of the screenshot
```
## Deliverables

A method that returns an object with specific properties to locate the element in the screenshot.
## Solution

``` js

var browser = {

  /**
  *
  * @param {String} selector
  * @param {getBoundingClientRectCb}
  */
  getBoundingClientRect: function(selector, callback) {}


    /**
    * @callback getBoundingClientRectCb
    * @param error
    * @param {Object} rect
    * @param {Number} rect.top
    * @param {Number} rect.right
    * @param {Number} rect.bottom
    * @param {Number} rect.left
    * @param {Number} rect.width
    * @param {Number} rect.height
   */
};
```
