### PR TITLE
Possibility to set differ options

### DIFF
--- a/lib/adapters/looks-same.js
+++ b/lib/adapters/looks-same.js
@@ -6,26 +6,29 @@ var objectAssign = require('object-assign');
 * LooksSame Adapter for use with Mugshot
 *
 * @implements {Differ}
+* @class
 */
-module.exports = objectAssign({}, Differ, {
+function LooksSameAdapter(userOptions) {
+  var options = {
+    highlightColor: '#ff00ff',
+    strict: true
+  };
 
+  this._options = objectAssign(options, userOptions);
+  this._options.diff = undefined;
+}
+
+LooksSameAdapter.prototype = objectAssign({}, Differ, {
   isEqual: function(img1, img2, callback) {
-    var options = {
-      strict: true
-    };
-
-    looksSame(img1, img2, options, callback);
+    looksSame(img1, img2, this._options, callback);
   },
 
   createDiff: function(img1, img2, callback) {
-    var options = {
-      reference: img1,
-      current: img2,
-      highlightColor: '#ff00ff',
-      strict: true,
-      save: false
-    };
+    this._options.reference = img1;
+    this._options.current = img2;
 
-    looksSame.createDiff(options, callback);
+    looksSame.createDiff(this._options, callback);
   }
 });
+
+module.exports = LooksSameAdapter;

--- a/lib/adapters/looks-same.js
+++ b/lib/adapters/looks-same.js
@@ -14,8 +14,11 @@ function LooksSameAdapter(userOptions) {
     strict: true
   };
 
-  this._options = objectAssign(options, userOptions);
-  this._options.diff = undefined;
+  this._options = objectAssign(options, userOptions, {diff: undefined});
+
+  if (this._options.tolerance !== undefined) {
+    this._options.strict = false;
+  }
 }
 
 LooksSameAdapter.prototype = objectAssign({}, Differ, {

--- a/lib/adapters/looks-same.js
+++ b/lib/adapters/looks-same.js
@@ -27,10 +27,12 @@ LooksSameAdapter.prototype = objectAssign({}, Differ, {
   },
 
   createDiff: function(img1, img2, callback) {
-    this._options.reference = img1;
-    this._options.current = img2;
+    var options = objectAssign({}, this._options, {
+      reference: img1,
+      current: img2
+    });
 
-    looksSame.createDiff(this._options, callback);
+    looksSame.createDiff(options, callback);
   }
 });
 

--- a/test/differ/differ-adapters.js
+++ b/test/differ/differ-adapters.js
@@ -1,8 +1,8 @@
 var tests = require('./differ-tests.js');
-var LooksSameAdaptor = require('../../lib/adapters/looks-same.js');
+var LooksSameAdapter = require('../../lib/adapters/looks-same.js');
 
-describe('LooksSame Adaptor', function() {
+describe('LooksSame Adapter', function() {
   tests(function() {
-    return LooksSameAdaptor;
+    return new LooksSameAdapter();
   });
 });

--- a/test/differ/differ-tests.js
+++ b/test/differ/differ-tests.js
@@ -1,12 +1,22 @@
 var expect = require('chai').expect;
+var fs = require('fs');
 var path = require('path');
 
 function composePath(file) {
-  return path.join(__dirname, 'data', file);
+  var ext = '.png';
+  return path.join(__dirname, 'data', file + ext);
 }
 
 function differTests(getDifferInstance) {
-  var differInstance;
+  var differInstance,
+      same = fs.readFileSync(composePath('same')),
+      different = fs.readFileSync(composePath('different')),
+      unnoticeable = fs.readFileSync(composePath('different-unnoticeable')),
+      tall = fs.readFileSync(composePath('tall')),
+      wide = fs.readFileSync(composePath('wide')),
+      strict = fs.readFileSync(composePath('strict')),
+      strictUnnoticeable = fs.readFileSync(composePath('strict-unnoticeable')),
+      sizes = fs.readFileSync(composePath('sizes'));
 
   beforeEach(function() {
     differInstance = getDifferInstance();
@@ -14,46 +24,43 @@ function differTests(getDifferInstance) {
 
   describe('isEqual method', function() {
     it('should return true for exactly same image', function(done) {
-      var img1 = composePath('same.png');
 
-      differInstance.isEqual(img1, img1, function(error, equal) {
+      differInstance.isEqual(same, same, function(error, equal) {
         expect(error).to.be.null;
         expect(equal).to.be.true;
+
         done();
       });
     });
 
     it('should return false for different images', function(done) {
-      var img1 = composePath('same.png');
-      var img2 = composePath('different.png');
 
-      differInstance.isEqual(img1, img2, function(error, equal) {
+      differInstance.isEqual(same, different, function(error, equal) {
         expect(error).to.be.null;
         expect(equal).to.be.false;
+
         done();
       });
     });
 
     it('should also return false if differences are unnoticeable',
       function(done) {
-        var img1 = composePath('same.png');
-        var img2 = composePath('different-unnoticeable.png');
 
-        differInstance.isEqual(img1, img2, function(error, equal) {
+        differInstance.isEqual(same, unnoticeable, function(error, equal) {
           expect(error).to.be.null;
           expect(equal).to.be.false;
+
           done();
         });
       }
     );
 
     it('should return false for images of different sizes', function(done) {
-      var img1 = composePath('wide.png');
-      var img2 = composePath('tall.png');
 
-      differInstance.isEqual(img1, img2, function(error, equal) {
+      differInstance.isEqual(tall, wide, function(error, equal) {
         expect(error).to.be.null;
         expect(equal).to.be.false;
+
         done();
       });
     });
@@ -61,14 +68,11 @@ function differTests(getDifferInstance) {
 
   describe('createDiff method', function() {
     it('should create a diff between 2 different images', function(done) {
-      var img1 = composePath('same.png');
-      var img2 = composePath('different.png');
-      var diff = composePath('strict.png');
 
-      differInstance.createDiff(img1, img2, function(error, data) {
+      differInstance.createDiff(same, different, function(error, data) {
         expect(error).to.be.null;
 
-        differInstance.isEqual(diff, data, function(error, equal) {
+        differInstance.isEqual(strict, data, function(error, equal) {
           expect(error).to.be.null;
           expect(equal).to.be.equal(true);
           done();
@@ -77,34 +81,30 @@ function differTests(getDifferInstance) {
     });
 
     it('should also create a proper diff if the differences are unnoticeable',
-      function(done) {
-        var img1 = composePath('same.png');
-        var img2 = composePath('different-unnoticeable.png');
-        var diff = composePath('strict-unnoticeable.png');
+       function(done) {
 
-        differInstance.createDiff(img1, img2, function(error, data) {
-          expect(error).to.be.null;
-
-          differInstance.isEqual(diff, data, function(error, equal) {
-            expect(error).to.be.null;
-            expect(equal).to.be.equal(true);
-            done();
-          });
-        });
-      }
-    );
-
-    it('should create a diff for images of different sizes', function(done) {
-      var img1 = composePath('tall.png');
-      var img2 = composePath('wide.png');
-      var diff = composePath('sizes.png');
-
-      differInstance.createDiff(img1, img2, function(error, data) {
+      differInstance.createDiff(same, unnoticeable, function(error, data) {
         expect(error).to.be.null;
 
-        differInstance.isEqual(diff, data, function(error, equal) {
+        differInstance.isEqual(strictUnnoticeable, data,
+         function(error, equal) {
           expect(error).to.be.null;
           expect(equal).to.be.equal(true);
+
+          done();
+        });
+      });
+    });
+
+    it('should create a diff for images of different sizes', function(done) {
+
+      differInstance.createDiff(tall, wide, function(error, data) {
+        expect(error).to.be.null;
+
+        differInstance.isEqual(sizes, data, function(error, equal) {
+          expect(error).to.be.null;
+          expect(equal).to.be.equal(true);
+
           done();
         });
       });

--- a/test/differ/look-same.js
+++ b/test/differ/look-same.js
@@ -1,0 +1,46 @@
+var expect = require('chai').expect;
+var LooksSameAdapter = require('../../lib/adapters/looks-same.js');
+var fs = require('fs');
+var path = require('path');
+
+function composePath(file) {
+  var ext = '.png';
+  return path.join(__dirname, 'data', file + ext);
+}
+
+describe('LooksSame Adaptor', function() {
+  var tall = fs.readFileSync(composePath('tall')),
+      wide = fs.readFileSync(composePath('wide')),
+      sizes = fs.readFileSync(composePath('sizes'));
+
+  it('should override the default highlightColor', function(done) {
+    var options = {
+          highlightColor: '#0000FF'
+        },
+        adapter = new LooksSameAdapter(options);
+
+    adapter.createDiff(tall, wide, function(error, diff) {
+      adapter.isEqual(diff, sizes, function(error, equal) {
+        expect(error).to.be.null;
+        expect(equal).to.be.false;
+
+        done();
+      });
+    });
+  });
+
+  it('should always return a buffer even if the user provides a diff path',
+     function(done) {
+    var options = {
+          diff: 'path'
+        },
+        adapter = new LooksSameAdapter(options);
+
+    adapter.createDiff(tall, wide, function(error, diff) {
+      expect(error).to.be.null;
+      expect(diff).to.be.an.instanceof(Buffer);
+
+      done();
+    });
+  });
+});

--- a/test/differ/look-same.js
+++ b/test/differ/look-same.js
@@ -8,7 +8,7 @@ function composePath(file) {
   return path.join(__dirname, 'data', file + ext);
 }
 
-describe('LooksSame Adaptor', function() {
+describe('LooksSame Adapter', function() {
   var tall = fs.readFileSync(composePath('tall')),
       wide = fs.readFileSync(composePath('wide')),
       sizes = fs.readFileSync(composePath('sizes'));
@@ -39,6 +39,21 @@ describe('LooksSame Adaptor', function() {
     adapter.createDiff(tall, wide, function(error, diff) {
       expect(error).to.be.null;
       expect(diff).to.be.an.instanceof(Buffer);
+
+      done();
+    });
+  });
+
+  it('should set strict to false if it receives a tolerance', function(done) {
+    var options = {
+          tolerance: 5,
+          strict: true
+        },
+        adapter = new LooksSameAdapter(options);
+
+    adapter.isEqual(tall, wide, function(error, equal) {
+      expect(error).to.be.null;
+      expect(equal).to.be.false;
 
       done();
     });


### PR DESCRIPTION
## Need

```gherkin
As a user
I need to have the possibility to set my diffing options
So that I can have more control over the diff process
```

## Deliverables

A better `LooksSame Adaptor`, that stores the user options and then uses it.

## Solution

Exactly like the [WebdriverIOAdaptor](https://github.com/uberVU/mugshot/blob/c1f3ef03c510401990bc41fbf01c72c6eef319ba/lib/adapters/webdriverio.js).

Constructor:
```js
function LooksSameAdapter(userOptions) {
   var options = {
     highlightColor: '#ff00ff',
     strict: true,
   };

   this._options = objectAssign(options, userOptions);
   this._options.diff = undefined;
}
```