### PR TITLE
Mugshot override default options

### DIFF
--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var objectAssign = require('object-assign');
 var LooksSameAdapter = require('./adapters/looks-same.js');
 
 /**
@@ -92,13 +93,14 @@ function Mugshot(browser, options) {
     throw new Error('options is not an obejct');
   }
 
-  options = options || {};
-  this._options = {};
+  var defaultOptions = {
+    differ: DEFAULT_DIFFER,
+    fs: DEFAULT_FS,
+    PNGProcessor: DEFAULT_PNGPROCESSOR,
+    rootDirectory: DEFAULT_ROOT_DIRECTORY
+  };
 
-  this._options.differ = options.differ || DEFAULT_DIFFER;
-  this._options.fs = options.fs || DEFAULT_FS;
-  this._options.PNGProcessor = options.PNGProcessor || DEFAULT_PNGPROCESSOR;
-  this._options.rootDirectory = options.rootDirectory || DEFAULT_ROOT_DIRECTORY;
+  this._options = objectAssign({}, defaultOptions, options);
 }
 
 /**


### PR DESCRIPTION
## Need

```gherkin
As a user
I need to have the possibility to override the default options
So that I can set my own
```

## Deliverables
Mugshot refurbishment of options override.

## Solution
Using [object-assign](https://www.npmjs.com/package/object-assign) to substitute [this](https://github.com/uberVU/mugshot/blob/2b69b5a7c308e38939d314a38ddacea5f7dd9ec8/lib/mugshot.js#L95-L101).