### PR TITLE
Mugshot result

### DIFF
--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -264,7 +264,10 @@ function _test(baseName, options, screenshot, done) {
           return done(error);
         }
 
-        done(null, true);
+        done(null, {
+          isEqual: true,
+          baseline: baselinePath
+        });
       });
     }
   });

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -334,7 +334,7 @@ function composeImagePath(rootDirectory, baseName) {
   return function(extensionName) {
     var name = baseName + extensionName + IMAGE_EXTENSION;
 
-    return path.join(rootDirectory, name);
+    return path.join(process.cwd(), rootDirectory, name);
   }
 }
 

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -202,7 +202,10 @@ function _unlinkScreenshotAndDiff(fs, paths, done) {
         return done(error);
       }
 
-      done(null, true);
+      done(null, {
+        isEqual: true,
+        baseline: paths.baselinePath
+      });
     });
   });
 }

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -156,13 +156,13 @@ Mugshot.prototype.test = function(captureItem, callback) {
  * Writes the screenshot and the diff on disk
  *
  * @param {FS} fs - File system adapter instance
- * @param {Object} paths - Contains the path of the screenshot and diff on disk
- * @param {String} paths.screenshotPath
- * @param {String} paths.diffPath
- * @param {Object} data - Contains the binary representation of the screenshot
- *    and the diff
- * @param {Buffer} data.screenshot
- * @param {Buffer} data.diff
+ * @param {Object} paths - Paths of the images
+ * @param {String} paths.baselinePath - The path of the baseline on disk
+ * @param {String} paths.screenshotPath - The path of the screenshot on disk
+ * @param {String} paths.diffPath - The path of the diff image on disk
+ * @param {Object} data - The images
+ * @param {Buffer} data.screenshot - The binary representation of the screenshot
+ * @param {Buffer} data.diff - The binary representation of the diff image
  * @param {testCb} done - Called when all operations have finished
  */
 function _writeScreenshotAndDiff(fs, paths, data, done) {
@@ -176,7 +176,12 @@ function _writeScreenshotAndDiff(fs, paths, data, done) {
         return done(error);
       }
 
-      done(null, false);
+      done(null, {
+        isEqual: false,
+        baseline: paths.baselinePath,
+        screenshot: paths.screenshotPath,
+        diff: paths.diffPath
+      });
     });
   });
 }

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -289,8 +289,11 @@ function _test(baseName, options, screenshot, done) {
  */
 function _diffImages(options, baseline, screenshot, done) {
   var differ = options.differ,
-      screenshotPath = options.getPath(SCREENSHOT_NAME),
-      diffPath = options.getPath(DIFF_NAME);
+      paths = {
+        baselinePath: options.getPath(BASELINE_NAME),
+        screenshotPath: options.getPath(SCREENSHOT_NAME),
+        diffPath: options.getPath(DIFF_NAME)
+      };
 
   differ.isEqual(baseline, screenshot, function(error, equal) {
     if (error) {
@@ -298,23 +301,12 @@ function _diffImages(options, baseline, screenshot, done) {
     }
 
     if (equal) {
-      var paths = {
-        baselinePath: options.getPath(BASELINE_NAME),
-        screenshotPath: screenshotPath,
-        diffPath: diffPath
-      };
-
       _unlinkScreenshotAndDiff(options.fs, paths, done);
     } else {
       differ.createDiff(baseline, screenshot, function(error, diff) {
         if (error) {
           return done(error);
         }
-
-        var paths = {
-          screenshotPath: screenshotPath,
-          diffPath: diffPath
-        };
 
         var data = {
           screenshot: screenshot,

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -185,17 +185,19 @@ function _writeScreenshotAndDiff(fs, paths, data, done) {
  * Unlinks from disk the screenshot and the diff image from a previous run
  *
  * @param {FS} fs - File system adapter instance
- * @param {String} screenshotPath - The path of the screenshot on disk
- * @param {String} diffPath - The path of the diff image on disk
+ * @param {Object} paths - Paths of the images
+ * @param {String} paths.baselinePath - The path of the baseline on disk
+ * @param {String} paths.screenshotPath - The path of the screenshot on disk
+ * @param {String} paths.diffPath - The path of the diff image on disk
  * @param {testCb} done - Called when all operations have finished
  */
-function _unlinkScreenshotAndDiff(fs, screenshotPath, diffPath, done) {
-  fs.unlink(screenshotPath, function(error) {
+function _unlinkScreenshotAndDiff(fs, paths, done) {
+  fs.unlink(paths.screenshotPath, function(error) {
     if (error && error.code !== 'ENOENT') {
       return done(error);
     }
 
-    fs.unlink(diffPath, function(error) {
+    fs.unlink(paths.diffPath, function(error) {
       if (error && error.code !== 'ENOENT') {
         return done(error);
       }
@@ -293,7 +295,13 @@ function _diffImages(options, baseline, screenshot, done) {
     }
 
     if (equal) {
-      _unlinkScreenshotAndDiff(options.fs, screenshotPath, diffPath, done);
+      var paths = {
+        baselinePath: options.getPath(BASELINE_NAME),
+        screenshotPath: screenshotPath,
+        diffPath: diffPath
+      };
+
+      _unlinkScreenshotAndDiff(options.fs, paths, done);
     } else {
       differ.createDiff(baseline, screenshot, function(error, diff) {
         if (error) {

--- a/tests/integration/test.js
+++ b/tests/integration/test.js
@@ -5,14 +5,13 @@ var WdioAdapter = require('../../lib/adapters/webdriverio.js');
 var path = require('path');
 var fs = require('fs');
 
-var name = 'great';
-var ext = '.png';
-var dir = path.join(__dirname, '..', '..', 'visual-tests');
+var name = 'great',
+    ext = '.png',
+    dir = path.join(__dirname, '..', '..', 'visual-tests'),
+    paths = [path.join(dir, name + ext), path.join(dir, name + '.new' + ext),
+             path.join(dir, name + '.diff' + ext)];
 
 function cleanUp() {
-  var paths = [path.join(dir, name + ext), path.join(dir, name + '.new' + ext),
-               path.join(dir, name + '.diff' + ext)];
-
   for (var i = 0; i < paths.length; i++) {
     try {
       fs.unlinkSync(paths[i]);
@@ -46,6 +45,16 @@ describe('Mugshot integration', function() {
       noDifferencesSelector = {
         name: name,
         selector: '#rectangle'
+      },
+      noDifferencesResult = {
+        isEqual: true,
+        baseline: paths[0]
+      },
+      differencesResult = {
+        isEqual: false,
+        baseline: paths[0],
+        screenshot: paths[1],
+        diff: paths[2]
       },
       wdioInstance, mugshot;
 
@@ -88,7 +97,7 @@ describe('Mugshot integration', function() {
 
     mugshot.test(noDifferencesSelector, function(error, result) {
       expect(error).to.be.null;
-      expect(result).to.be.true;
+      expect(result).to.be.deep.equal(noDifferencesResult);
 
       done();
     });
@@ -97,7 +106,7 @@ describe('Mugshot integration', function() {
   it('should be true if there are no differences', function(done) {
     mugshot.test(noDifferencesSelector, function(error, result) {
       expect(error).to.be.null;
-      expect(result).to.be.true;
+      expect(result).to.be.deep.equal(noDifferencesResult);
 
       done();
     });
@@ -106,7 +115,7 @@ describe('Mugshot integration', function() {
   it('should be false if there are differences', function(done) {
     mugshot.test(differencesSelector, function(error, result) {
       expect(error).to.be.null;
-      expect(result).to.be.false;
+      expect(result).to.be.deep.equal(differencesResult);
 
       done();
     });

--- a/tests/integration/test.js
+++ b/tests/integration/test.js
@@ -92,7 +92,8 @@ describe('Mugshot integration', function() {
     });
   });
 
-  it('should be true if there is no previous baseline', function(done) {
+  it('should be true and contain only baseline path if there is no previous ' +
+     'baseline', function(done) {
     cleanUp();
 
     mugshot.test(noDifferencesSelector, function(error, result) {
@@ -103,7 +104,8 @@ describe('Mugshot integration', function() {
     });
   });
 
-  it('should be true if there are no differences', function(done) {
+  it('should be true and contain only baseline path if there are no ' +
+     'differences', function(done) {
     mugshot.test(noDifferencesSelector, function(error, result) {
       expect(error).to.be.null;
       expect(result).to.be.deep.equal(noDifferencesResult);
@@ -112,7 +114,8 @@ describe('Mugshot integration', function() {
     });
   });
 
-  it('should be false if there are differences', function(done) {
+  it('should be false and contain all images paths if there are differences',
+     function(done) {
     mugshot.test(differencesSelector, function(error, result) {
       expect(error).to.be.null;
       expect(result).to.be.deep.equal(differencesResult);

--- a/tests/unit/no-baseline.js
+++ b/tests/unit/no-baseline.js
@@ -12,7 +12,8 @@ describe('No baseline', function() {
       error = new Error('Fatal Error'),
       rootDirectory = 'visual-tests',
       extension = '.png',
-      baselinePath = path.join(rootDirectory, noSelector.name + extension),
+      baselinePath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + extension),
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {

--- a/tests/unit/no-baseline.js
+++ b/tests/unit/no-baseline.js
@@ -14,6 +14,10 @@ describe('No baseline', function() {
       extension = '.png',
       baselinePath = path.join(process.cwd(), rootDirectory,
         noSelector.name + extension),
+      result = {
+        isEqual: true,
+        baseline: baselinePath
+      },
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {
@@ -75,6 +79,6 @@ describe('No baseline', function() {
 
     mugshot.test(noSelector, callback);
 
-    expect(callback).to.have.been.calledWithExactly(null, true);
+    expect(callback).to.have.been.calledWithExactly(null, result);
   });
 });

--- a/tests/unit/no-baseline.js
+++ b/tests/unit/no-baseline.js
@@ -74,7 +74,7 @@ describe('No baseline', function() {
     expect(callback).to.have.been.calledWithExactly(error);
   });
 
-  it('should return true through the cb', function() {
+  it('should return true and only baseline path through the cb', function() {
     FS.writeFile.yields(null);
 
     mugshot.test(noSelector, callback);

--- a/tests/unit/no-differences.js
+++ b/tests/unit/no-differences.js
@@ -111,7 +111,7 @@ describe('No differences', function() {
     expect(callback).to.have.been.calledWithExactly(error);
   });
 
-  it('should return true through the cb', function() {
+  it('should return true and only baseline path through the cb', function() {
     FS.unlink.yields(null);
     FS.unlink.yields(null);
 

--- a/tests/unit/no-differences.js
+++ b/tests/unit/no-differences.js
@@ -11,10 +11,10 @@ describe('No differences', function() {
       error = new Error('Fatal Error'),
       rootDirectory = 'visual-tests',
       extension = '.png',
-      screenshotPath = path.join(rootDirectory, noSelector.name + '.new' +
-        extension),
-      diffPath = path.join(rootDirectory, noSelector.name + '.diff' +
-        extension),
+      screenshotPath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + '.new' + extension),
+      diffPath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + '.diff' + extension),
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {

--- a/tests/unit/no-differences.js
+++ b/tests/unit/no-differences.js
@@ -15,6 +15,12 @@ describe('No differences', function() {
         noSelector.name + '.new' + extension),
       diffPath = path.join(process.cwd(), rootDirectory,
         noSelector.name + '.diff' + extension),
+      baselinePath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + extension),
+      result = {
+        isEqual: true,
+        baseline: baselinePath
+      },
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {
@@ -111,6 +117,6 @@ describe('No differences', function() {
 
     mugshot.test(noSelector, callback);
 
-    expect(callback).to.have.been.calledWithExactly(null, true);
+    expect(callback).to.have.been.calledWithExactly(null, result);
   });
 });

--- a/tests/unit/with-baseline.js
+++ b/tests/unit/with-baseline.js
@@ -13,7 +13,8 @@ describe('With baseline', function() {
       error = new Error('Fatal Error'),
       rootDirectory = 'visual-tests',
       extension = '.png',
-      baselinePath = path.join(rootDirectory, noSelector.name + extension),
+      baselinePath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + extension),
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {

--- a/tests/unit/with-differences.js
+++ b/tests/unit/with-differences.js
@@ -18,6 +18,14 @@ describe('With differences', function() {
         noSelector.name + '.new' + extension),
       diffPath = path.join(process.cwd(), rootDirectory,
         noSelector.name + '.diff' + extension),
+      baselinePath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + extension),
+      result = {
+        isEqual: false,
+        baseline: baselinePath,
+        screenshot: screenshotPath,
+        diff: diffPath
+      },
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {
@@ -113,6 +121,6 @@ describe('With differences', function() {
 
     mugshot.test(noSelector, callback);
 
-    expect(callback).to.have.been.calledWithExactly(null, false);
+    expect(callback).to.have.been.calledWithExactly(null, result);
   });
 });

--- a/tests/unit/with-differences.js
+++ b/tests/unit/with-differences.js
@@ -14,10 +14,10 @@ describe('With differences', function() {
       error = new Error('Fatal Error'),
       rootDirectory = 'visual-tests',
       extension = '.png',
-      screenshotPath = path.join(rootDirectory, noSelector.name + '.new' +
-        extension),
-      diffPath = path.join(rootDirectory, noSelector.name + '.diff' +
-        extension),
+      screenshotPath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + '.new' + extension),
+      diffPath = path.join(process.cwd(), rootDirectory,
+        noSelector.name + '.diff' + extension),
       callback, mugshot, browser, FS, differ;
 
   beforeEach(function() {

--- a/tests/unit/with-differences.js
+++ b/tests/unit/with-differences.js
@@ -115,7 +115,8 @@ describe('With differences', function() {
     expect(callback).to.have.been.calledWithExactly(error);
   });
 
-  it('should return false through the callback', function() {
+  it('should return false and all images paths through the callback',
+     function() {
     differ.createDiff.yields(null, diff);
     FS.writeFile.yields(null);
 

--- a/tests/unit/with-selector.js
+++ b/tests/unit/with-selector.js
@@ -21,7 +21,8 @@ describe('With selector', function() {
       error = new Error('Fatal Error'),
       rootDirectory = 'visual-tests',
       extension = '.png',
-      baselinePath = path.join(rootDirectory, withSelector.name + extension),
+      baselinePath = path.join(process.cwd(), rootDirectory,
+        withSelector.name + extension),
       callback, mugshot, browser, PNGProcessor, FS;
 
   beforeEach(function() {


### PR DESCRIPTION
## Need

```gherkin
As a developer
I need to have more informations about the tests
So that I can process the data and present it further
As a user
I need to have more informations about the tests
So that I can figure out why my tests are failing
```

## Deliverables

For now the **absolute paths** of the `baseline` and/or `screenshot` and `diff`.

Also update `Mugshot` to work internally with `absolute paths`.

## Solution

To update `Mugshot` to work with absolute paths, we must only update the [buildPath](https://github.com/uberVU/mugshot/blob/25399353a6a69dd66c5982007d02c0f146566fb0/lib/mugshot.js#L337) function.

Returning an object through the callback:

```js
var result = {
  equal: Boolean,
  baseline: String,
  screenshot: String,
  diff: String
};
```
When [no baseline exists](https://github.com/uberVU/mugshot/blob/25399353a6a69dd66c5982007d02c0f146566fb0/lib/mugshot.js#L267) to return an object only with `equal` and `baseline` props.

The same when [there are no differences](https://github.com/uberVU/mugshot/blob/25399353a6a69dd66c5982007d02c0f146566fb0/lib/mugshot.js#L203).

And when [there are differences](https://github.com/uberVU/mugshot/blob/25399353a6a69dd66c5982007d02c0f146566fb0/lib/mugshot.js#L179) to return the full object.