### PR TITLE
Added acceptFirstBaseline option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The options object is optional and has the following keys:
 - **rootDirectory** - the path where the screenshots and diffs will be saved;
   defaults to `visual-tests`.
 - **acceptFirstBaseline** - whether the test should pass if the selector is
-  tested for the first time. Defaults to `true`.
+  tested for the first time. The baseline will be saved to the file system
+  regardless of this option. Defaults to `true`.
 
 If any of the implementations are not provided, Mugshot's defaults are used.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The options object is optional and has the following keys:
   interface](lib/interfaces/png-processor.js),
 - **rootDirectory** - the path where the screenshots and diffs will be saved;
   defaults to `visual-tests`.
+- **acceptFirstBaseline** - whether the test should pass if the selector is
+  tested for the first time. Defaults to `true`.
 
 If any of the implementations are not provided, Mugshot's defaults are used.
 
@@ -129,7 +131,8 @@ Mugshot will use the provided name to create the following files:
 - **<name>.diff.png** - the diff between the above two.
 
 If testing a selector for the first time, the baseline screenshot will be saved
-and the test will pass. If the baseline is found on the file system, a new
+and the test will pass if `acceptFirstBaseline` is set to true.
+If the baseline is found on the file system, a new
 screenshot will be taken and compared with it. If and **only if** there are
 differences, the other 2 files will be saved to the file sysem. If there are no
 differences, the files will be cleaned up from the file system so that you're
@@ -145,7 +148,7 @@ system and will receive 2 arguments:
     `false` then you can find the `.diff.png` and `.new.png` files on the file
     system.
   - **baseline** - String indicating the path of the baseline on disk.
-  - **screenshot** - String indicating the path of the screenshot on disk; only 
+  - **screenshot** - String indicating the path of the screenshot on disk; only
     if `isEqual` is `false`, else `undefined`.
   - **diff** - String indicating the path of the diff on disk; only if `isEqual`
     is `false`, else `undefined`.

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -79,6 +79,7 @@ var DIFF_NAME = '.diff';
  * @param {FS} [options.fs] - A module to interact with the file system
  * @param {String} [options.rootDirectory='visual-tests'] - The directory
  *     where the screenshots will be saved
+ * @param {Boolean} [options.acceptFirstBaseline] - Auto accept first baseline
  * @constructor
  */
 function Mugshot(browser, options) {

--- a/lib/mugshot.js
+++ b/lib/mugshot.js
@@ -97,7 +97,8 @@ function Mugshot(browser, options) {
     differ: DEFAULT_DIFFER,
     fs: DEFAULT_FS,
     PNGProcessor: DEFAULT_PNGPROCESSOR,
-    rootDirectory: DEFAULT_ROOT_DIRECTORY
+    rootDirectory: DEFAULT_ROOT_DIRECTORY,
+    acceptFirstBaseline: true
   };
 
   this._options = objectAssign({}, defaultOptions, options);
@@ -275,7 +276,7 @@ function _test(baseName, options, screenshot, done) {
         }
 
         done(null, {
-          isEqual: true,
+          isEqual: options.acceptFirstBaseline,
           baseline: baselinePath
         });
       });

--- a/tests/integration/test.js
+++ b/tests/integration/test.js
@@ -129,3 +129,65 @@ describe('Mugshot integration', function() {
     return wdioInstance.end();
   });
 });
+
+describe('Mugshot integration with disabled acceptFirstBaseline', function() {
+  this.timeout(0);
+
+  var url = 'file://' + path.join(__dirname, 'test.html'),
+      noDifferencesSelector = {
+        name: name,
+        selector: '#rectangle'
+      },
+      noBaselineResult = {
+        isEqual: false,
+        baseline: paths[0]
+      },
+      wdioInstance, mugshot;
+
+  before(function() {
+    var options = {
+      desiredCapabilities: {
+        browserName: 'phantomjs'
+      }
+    };
+
+    var mugshotOptions = {
+      acceptFirstBaseline: false
+    };
+
+    return wdioInstance = wdio.remote(options).init().url(url).then(function() {
+      var browser = new WdioAdapter(this);
+      mugshot = new Mugshot(browser, mugshotOptions);
+    });
+  });
+
+  beforeEach(function(done) {
+    cleanUp();
+
+    mugshot.test(noDifferencesSelector, function(error) {
+      if (error) {
+        throw error;
+      }
+
+      done();
+    });
+  });
+
+
+  it('should be false and contain only baseline path if there is no previous ' +
+     'baseline', function(done) {
+    cleanUp();
+
+    mugshot.test(noDifferencesSelector, function(error, result) {
+      expect(error).to.be.null;
+      expect(result).to.be.deep.equal(noBaselineResult);
+
+      done();
+    });
+  });
+
+  after(function() {
+    cleanUp();
+    return wdioInstance.end();
+  });
+});

--- a/tests/unit/no-baseline.js
+++ b/tests/unit/no-baseline.js
@@ -81,4 +81,25 @@ describe('No baseline', function() {
 
     expect(callback).to.have.been.calledWithExactly(null, result);
   });
+
+  it('should return false when acceptFirstBaseline is disabled and baseline ' +
+     'doesn\'t exist.', function() {
+    FS.writeFile.yields(null);
+
+    var options = {
+      fs: FS,
+      differ: differ,
+      acceptFirstBaseline: false
+    };
+
+    // create local mugshot instance with different options
+    var mugshot = new Mugshot(browser, options);
+    var result = {
+      isEqual: false,
+      baseline: baselinePath
+    };
+
+    mugshot.test(noSelector, callback);
+    expect(callback).to.have.been.calledWithExactly(null, result);
+  });
 });


### PR DESCRIPTION
Test should fail when baseline doesn't exist in some environments (like CI). I've added simple option to mugshot constructor, whether test should fail or pass when baseline doesn't exist.