### PR TITLE
Upgrade png-crop version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mugshot",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "visual regression testing",
   "contributors": [{
     "name": "Florentin Simion"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "concat-stream": "^1.5.0",
     "looks-same": "^2.1.0",
     "object-assign": "^3.0.0",
-    "png-crop": "0.0.0",
+    "png-crop": "0.0.1",
     "mkdirp": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Problem

The version of `png-crop` is `0.0.0` and this has a dependency on a very old version of `pngjs`, which has an engine dependency on Node `0.8.x`. See [here](https://github.com/chenglou/png-crop/commit/0833290a5fabb797d7283b584acc7eec3ebb3f5c) and [here](https://github.com/lukeapage/pngjs/blob/82dd9a96c00eabb2b9051edb6d7b45fed944111d/package.json).

When using mugshot inside ui-components we cannot add yarn to the project because we are running the build on Node 6. 

# Solution

Upgrade version of `png-crop` to `0.0.1` which has a dependency on `pngjs` version `^2.2.0` and the latest release, `2.3.1`, has the following engine dependency:

```
"engines": {
  "node": ">=0.10.0",
  "iojs": ">= 1.0.0"
},
```
